### PR TITLE
Moving NotFoundHandler to Middleware package

### DIFF
--- a/controller/middleware/middleware.go
+++ b/controller/middleware/middleware.go
@@ -9,6 +9,30 @@ import (
 	"github.com/labstack/echo"
 )
 
+/*
+// NotFoundHandler is a middleware that checks if a route exists. If it doesn't, it returns 404 Page Not Found
+func NotFoundHandler() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			var notFoundHandler = func(c echo.Context) error {
+				return c.String(http.StatusNotFound, "Page not found")
+			}
+
+			c.SetHandler(notFoundHandler)
+			next(c)
+			return nil
+		}
+	}
+}
+*/
+
+// NotFoundHandler sets the NotFoundHandler of Echo's context to return 404 upon non-existent routes
+func NotFoundHandler() {
+	echo.NotFoundHandler = func(c echo.Context) error {
+		return c.String(http.StatusNotFound, "Page not found")
+	}
+}
+
 // DbAccessMiddleware is a middleware that sets the database connection object using "db" as key
 func DbAccessMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"strconv"
 
@@ -18,13 +17,9 @@ import (
 
 func main() {
 
-	// Handler for "not found" routes
-
-	echo.NotFoundHandler = func(c echo.Context) error {
-		return c.String(http.StatusNotFound, "Page not found")
-	}
-
 	ech := echo.New()
+
+	middleware.NotFoundHandler()
 
 	ech.Use(middleware.DbAccessMiddleware())
 


### PR DESCRIPTION
Should fix #3 .

Per your request, here's the Not Found routes handler moved to the middleware package. I've added a commented piece of code that you can use the function as middleware. However, I advise against that.
From what I've gathered, when creating a new instance of Echo, you can set the Handler through context, removing the need to create a dedicated middleware. Echo even has this handler completely separated from the middleware pipeline. Therefore, it's only useful to set this handler once (on initiation). 
The following snippet is from echo.go, from the library itself, which clearly shows the *middleware* and the *handler* as two completely different fields and how the latter is set whilst creating a new context.

```
Echo struct {
        ...
	premiddleware    []MiddlewareFunc
	middleware       []MiddlewareFunc // < ----
	maxParam         *int
	router           *Router
	routers          map[string]*Router
	notFoundHandler  HandlerFunc // < ----
	pool             sync.Pool
	Server           *http.Server
        ....
}

[...]

// NewContext returns a Context instance.
func (e *Echo) NewContext(r *http.Request, w http.ResponseWriter) Context {
	return &context{
		request:  r,
		response: NewResponse(w, e),
		store:    make(Map),
		echo:     e,
		pvalues:  make([]string, *e.maxParam),
		handler:  NotFoundHandler,
	}
}
```

However, if you want to set this through your middleware pipeline, you can uncomment the code I've added, even though it creates un-needed overhead on each HTTP call.