### PR TITLE
Returning the handler and setting Echo's Not Found handler on Main

### DIFF
--- a/controller/middleware/middleware.go
+++ b/controller/middleware/middleware.go
@@ -9,27 +9,10 @@ import (
 	"github.com/labstack/echo"
 )
 
-/*
-// NotFoundHandler is a middleware that checks if a route exists. If it doesn't, it returns 404 Page Not Found
-func NotFoundHandler() echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			var notFoundHandler = func(c echo.Context) error {
-				return c.String(http.StatusNotFound, "Page not found")
-			}
-
-			c.SetHandler(notFoundHandler)
-			next(c)
-			return nil
-		}
-	}
-}
-*/
-
 // NotFoundHandler sets the NotFoundHandler of Echo's context to return 404 upon non-existent routes
-func NotFoundHandler() {
-	echo.NotFoundHandler = func(c echo.Context) error {
-		return c.String(http.StatusNotFound, "Page not found")
+func NotFoundHandler() func(c echo.Context) error {
+	return func(c echo.Context) error {
+		return c.NoContent(http.StatusNotFound)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -17,9 +17,9 @@ import (
 
 func main() {
 
-	ech := echo.New()
+	echo.NotFoundHandler = middleware.NotFoundHandler()
 
-	middleware.NotFoundHandler()
+	ech := echo.New()
 
 	ech.Use(middleware.DbAccessMiddleware())
 


### PR DESCRIPTION
There you go, this should finally close #3 with your requests!

Although, if I may say so myself, I feel like the use of HTTP codes are not adequate here. As it stands, one can't pinpoint if the request *exists* and is returning nothing or if it doesn't exist at all, as both return HTTP 404. 

My suggestion would be simple. For example, if I were to do a GET request to ```/schools``` and there were none to be found, you should return a HTTP 200 with an empty body (or empty array, if you'd like that). This way, one can pinpoint if the URI is actually correct. 

My suggestion would be:

- HTTP 200 - when returning empty bodies or arrays (or, in case of data, sending the data within)
- HTTP 404 - for non-existent routes
- HTTP 204 - when I do a PUT/PATCH request and it is successful. 
- HTTP 201 (Created) - when a POST request is successful

I'm not alone on this, here's [one](https://medium.com/@santhoshkumarkrishna/http-get-rest-api-no-content-404-vs-204-vs-200-6dd869e3af1d) and [another](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Status/204) and [another](https://stackoverflow.com/questions/13366730/proper-rest-response-for-empty-table) source if you want to.

This would be an issue on its own though :] 