### PR TITLE
Changing HTTP codes accordingly.

### DIFF
--- a/controller/canteen/api.go
+++ b/controller/canteen/api.go
@@ -35,7 +35,7 @@ func AvailableCanteens(c echo.Context) error {
 	// No need to check slice length as a school requires at least one canteen
 
 	if err != nil {
-		return c.NoContent(http.StatusNotFound)
+		return c.NoContent(http.StatusInternalServerError)
 	}
 
 	_canteens := _school.Canteens()

--- a/controller/dish/api.go
+++ b/controller/dish/api.go
@@ -70,7 +70,7 @@ func AvailableDishes(c echo.Context) error {
 	_dishes := _menu.Dishes()
 
 	if len(_dishes) == 0 {
-		return c.NoContent(http.StatusNotFound)
+		return c.NoContent(http.StatusOK)
 	}
 
 	modelview := view.ToGetAvailableDishesModelView(_dishes)

--- a/controller/menu/api.go
+++ b/controller/menu/api.go
@@ -48,7 +48,7 @@ func AvailableMenus(c echo.Context) error {
 	_menus := _canteen.AvailableMenus()
 
 	if len(_menus) == 0 {
-		return c.NoContent(http.StatusNotFound)
+		return c.NoContent(http.StatusOK)
 	}
 
 	modelview := view.ToGetAvailableMenusModelView(_menus)

--- a/controller/school/api.go
+++ b/controller/school/api.go
@@ -32,8 +32,10 @@ func AvailableSchools(c echo.Context) error {
 
 	err := db.Find(&schools).Error
 
-	if err != nil || len(schools) == 0 {
-		return c.NoContent(http.StatusNotFound)
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	} else if len(schools) == 0 {
+		return c.NoContent(http.StatusOK)
 	}
 
 	modelview := view.ToGetAvailableSchoolsModelView(schools)


### PR DESCRIPTION
This is related to my suggestion for #6. Decided to keep this as a separate pull request to allow you to either accept it or not (same explanation for why I've not initiated a pull request on the respective documentation).

What I've done here is essentially changing the HTTP code response when the query to the database is successful but there are no records to retrieve. In these cases, it returns an HTTP 200 with an empty body. If an error has occurred whilst querying the database, it throws an HTTP 500 code instead.

This is my suggestion as it makes more sense to me but it's up to you!